### PR TITLE
Potential fix for code scanning alert no. 2: Overly permissive file permissions

### DIFF
--- a/tests/unit/test_persistence.py
+++ b/tests/unit/test_persistence.py
@@ -402,7 +402,7 @@ class TestDatabaseErrorHandling:
 
         finally:
             # Clean up
-            os.chmod(readonly_dir, 0o755)
+            os.chmod(readonly_dir, 0o700)
             shutil.rmtree(readonly_dir, ignore_errors=True)
 
     def test_sqlite_corrupted_database(self, tmp_path):


### PR DESCRIPTION
Potential fix for [https://github.com/Kirch77/syntha/security/code-scanning/2](https://github.com/Kirch77/syntha/security/code-scanning/2)

To fix the problem, we should change the permission mask in the `os.chmod(readonly_dir, 0o755)` call to a more restrictive value. The best practice is to set the directory permissions to `0o700`, which allows only the owner to read, write, and execute. This change should be made directly on line 405 in the `finally` block of the `test_sqlite_connection_to_readonly_directory` method in `tests/unit/test_persistence.py`. No additional imports or definitions are needed, as `os.chmod` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
