### PR TITLE
Potential fix for code scanning alert no. 1: Overly permissive file permissions

### DIFF
--- a/tests/unit/test_persistence.py
+++ b/tests/unit/test_persistence.py
@@ -388,7 +388,7 @@ class TestDatabaseErrorHandling:
 
         # Create read-only directory
         readonly_dir = tempfile.mkdtemp()
-        os.chmod(readonly_dir, 0o444)
+        os.chmod(readonly_dir, 0o500)
 
         try:
             db_path = os.path.join(readonly_dir, "readonly.db")


### PR DESCRIPTION
Potential fix for [https://github.com/Kirch77/syntha/security/code-scanning/1](https://github.com/Kirch77/syntha/security/code-scanning/1)

To fix the problem, we should restrict the permissions set by `os.chmod(readonly_dir, 0o444)` to prevent world-readability. For directories, the minimum permissions required to allow the owner to traverse and read the directory are read and execute (`0o500`). This mask gives the owner read and execute permissions, and denies all permissions to group and others. The change should be made in the test method `test_sqlite_connection_to_readonly_directory` in `tests/unit/test_persistence.py`, replacing `os.chmod(readonly_dir, 0o444)` with `os.chmod(readonly_dir, 0o500)`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
